### PR TITLE
Fix Remedium Talisman breaking other items

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
+++ b/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
@@ -174,7 +174,7 @@ public class ItemCleansingTalisman extends ItemBase implements IBauble {
                         par1ItemStack.damageItem(damage, player);
                         if(par1ItemStack.getItemDamage()<=0)
                             {
-                                BaublesApi.getBaubles((EntityPlayer) player).setInventorySlotContents(0,null);
+                                BaublesApi.getBaubles((EntityPlayer) player).setInventorySlotContents(0,null); //Slot 0 = Talisman Slot
                             }
                         par2World.playSoundAtEntity(player, "thaumcraft:wand", 0.3F, 0.1F);
                     }

--- a/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
+++ b/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
@@ -174,7 +174,7 @@ public class ItemCleansingTalisman extends ItemBase implements IBauble {
                         par1ItemStack.damageItem(damage, player);
                         if(par1ItemStack.getItemDamage()<=0)
                             {
-                                BaublesApi.getBaubles((EntityPlayer) player).setInventorySlotContents(BaubleType.AMULET.ordinal(),null);
+                                BaublesApi.getBaubles((EntityPlayer) player).setInventorySlotContents(0,null);
                             }
                         par2World.playSoundAtEntity(player, "thaumcraft:wand", 0.3F, 0.1F);
                     }


### PR DESCRIPTION
When the Remedium Talisman breaks, it always breaks the item in the first ring slot instead. `BaubleType.AMULET.ordinal()`, whose value is 1, is incorrect. The `BaubleType` Enum is not bauble slot numbers.

The correct slot number for the amulet slot is 0. I don't see any constants to use for the amulet slots.

Fixes GTNewHorizons/NewHorizons#2615