### PR TITLE
Increase discount of ichor armors

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemIchorclothArmor.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemIchorclothArmor.java
@@ -83,7 +83,7 @@ public class ItemIchorclothArmor extends ItemArmor implements IVisDiscountGear, 
     }
 
     @Override
-    public void addInformation(final ItemStack stack, final EntityPlayer player, final List list, final boolean par4) 
+    public void addInformation(final ItemStack stack, final EntityPlayer player, final List list, final boolean par4)
     {
         list.add(EnumChatFormatting.DARK_PURPLE + StatCollector.translateToLocal("tc.visdiscount") + ": " + this.getVisDiscount(stack, player, null) + "%");
     }
@@ -115,7 +115,7 @@ public class ItemIchorclothArmor extends ItemArmor implements IVisDiscountGear, 
 
     @Override
     public int getVisDiscount(ItemStack arg0, EntityPlayer arg1, Aspect arg2) {
-        return 5;
+        return 6;
     }
 
     @Override

--- a/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemIchorclothArmorAdv.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemIchorclothArmorAdv.java
@@ -75,12 +75,12 @@ public abstract class ItemIchorclothArmorAdv extends ItemIchorclothArmor {
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
         return slot == 2 ? LibResources.MODEL_ARMOR_ICHOR_GEM_2 : LibResources.MODEL_ARMOR_ICHOR_GEM_1;
     }
-    
+
     @Override
     public int getVisDiscount(ItemStack arg0, EntityPlayer arg1, Aspect arg2) {
-        return 6;
+        return 10;
     }
-    
+
 
     boolean ticks() {
         return false;


### PR DESCRIPTION
Buffs normal ichorcloth armor to 6% from 5%, and the upgraded variants to 10% from 6%.

Ichor is effectively the endgame of thaumcraft, yet ichor armor and especially the upgraded ichor armor has a comparatively poor vis discount vs the investment required to get it.