### PR TITLE
keybind

### DIFF
--- a/src/main/java/thaumic/tinkerer/client/core/handler/GemArmorKeyHandler.java
+++ b/src/main/java/thaumic/tinkerer/client/core/handler/GemArmorKeyHandler.java
@@ -19,7 +19,7 @@ import thaumic.tinkerer.common.item.kami.armor.ItemIchorclothArmorAdv;
 @SideOnly(Side.CLIENT)
 public class GemArmorKeyHandler {
 
-    static KeyBinding SpecialAbility = new KeyBinding("ttmisc.toggleArmor", Keyboard.KEY_U, "ttmisc.keyCategory");
+    static KeyBinding SpecialAbility = new KeyBinding("ttmisc.toggleArmor", Keyboard.KEY_NONE, "ttmisc.keyCategory");
 
     public GemArmorKeyHandler() {
         FMLCommonHandler.instance().bus().register(this);


### PR DESCRIPTION
The goal is to unbind all keys that are not used from the start of the game in the GTNH modpack to avoid all the current keybinds conflict and leave to the user the choice of the keybinds they want.