### PR TITLE
Talisman of Remedium no longer wastes durability trying to remove permanent debuffs. It also accepts the Unbreaking enchant.

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
+++ b/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
@@ -168,6 +168,11 @@ public class ItemCleansingTalisman extends ItemBase implements IBauble {
                         player.extinguish();
                         removed = true;
                     } else for (PotionEffect potion : potions) {
+                        if (potion.duration < 20) {
+                            // Permanent effect, e.g., Dolly, TiC Cleaver, ...
+                            continue;
+                        }
+
                         int id = potion.getPotionID();
                         boolean badEffect;
                         badEffect = ReflectionHelper.getPrivateValue(

--- a/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
+++ b/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
@@ -143,6 +143,12 @@ public class ItemCleansingTalisman extends ItemBase implements IBauble {
     }
 
     @Override
+    public int getItemEnchantability() {
+        // Equivalent to iron.
+        return 10;
+    }
+
+    @Override
     public BaubleType getBaubleType(ItemStack itemstack) {
         return BaubleType.AMULET;
     }
@@ -186,7 +192,7 @@ public class ItemCleansingTalisman extends ItemBase implements IBauble {
                     if (removed) {
 
                         par1ItemStack.damageItem(damage, player);
-                        if (par1ItemStack.getItemDamage() <= 0) {
+                        if (par1ItemStack.stackSize <= 0) {
                             BaublesApi.getBaubles((EntityPlayer) player).setInventorySlotContents(0, null); // Slot 0 =
                                                                                                             // Talisman
                                                                                                             // Slot

--- a/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
+++ b/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
@@ -11,9 +11,11 @@
  */
 package thaumic.tinkerer.common.item;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.UUID;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
@@ -61,8 +63,8 @@ public class ItemCleansingTalisman extends ItemBase implements IBauble {
 
     private static final int EFFECT_BURNING = -1;
     // 0 = no effect, otherwise either EFFECT_BURNING or the ID of the effect removed.
-    private int lastEffectRemoved = 0;
-    private final Collection<Integer> permanentEffects = new ArrayList<>();
+    private HashMap<UUID, Integer> mLastEffectRemoved = new HashMap<>();
+    private final HashMap<UUID, Collection<Integer>> mPermanentEffects = new HashMap<>();
 
     public ItemCleansingTalisman() {
         setMaxStackSize(1);
@@ -164,8 +166,22 @@ public class ItemCleansingTalisman extends ItemBase implements IBauble {
             if (player.ticksExisted % 20 == 0) {
                 if (player instanceof EntityPlayer) {
 
+                    int lastEffectRemoved;
+                    Collection<Integer> permanentEffects;
+
+                    UUID uuid = player.getUniqueID();
+                    if (mPermanentEffects.containsKey(uuid)) {
+                        lastEffectRemoved = mLastEffectRemoved.get(uuid);
+                        permanentEffects = mPermanentEffects.get(uuid);
+                    } else {
+                        lastEffectRemoved = 0;
+                        permanentEffects = new HashSet<>();
+                        mLastEffectRemoved.put(uuid, lastEffectRemoved);
+                        mPermanentEffects.put(uuid, permanentEffects);
+                    }
+
                     // All effects we try to remove in this operation, including permanent effects.
-                    Collection<Integer> effectsToRemove = new ArrayList<>();
+                    Collection<Integer> effectsToRemove = new HashSet<>();
                     // One new effect we remove this operation, with a durability cost.
                     int effectRemoved = 0;
 
@@ -250,6 +266,7 @@ public class ItemCleansingTalisman extends ItemBase implements IBauble {
                     }
 
                     lastEffectRemoved = effectRemoved;
+                    mLastEffectRemoved.put(uuid, lastEffectRemoved);
                 }
             }
         }


### PR DESCRIPTION
This PR contains three changes:

* The Talisman of Remedium now ignores any debuffs that have a duration of < 1 second. This means it will not attempt to remove permanent debuffs caused by picking up containers using a dolly, by wielding a TiC cleaver, from hunger, etc.

* The talisman also attempts to detect other "permanent" debuffs, which are being reapplied to the player even after removed. For example, debuffs for holding a super tank, or from standing in poison or fire. If a player is affected by such a debuff, the talisman will not keep consuming durability or making noise trying to remove the debuff. The debuff will then be silently removed when the condition that keeps reapplying it stops doing so. (E.g., when the player places down the super tank.)

* Finally, the talisman can now be enchanted with the Unbreaking enchant using any standard means. The enchant functions identically to other tools; i.e., adds a chance not to consume durability with every use.

I have also planned to support the Repair enchant; however it seems to be hardcoded in base TC to only check items in the player's hotbar and armor slots. If anyone (@Alastors ?) wants to poke at it and make it apply to bauble slots too, I would be happy to add support.