### PR TITLE
Add configs for annoying Kami features

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.21'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.22'
 }
 
 

--- a/src/main/java/thaumic/tinkerer/common/core/handler/ConfigHandler.java
+++ b/src/main/java/thaumic/tinkerer/common/core/handler/ConfigHandler.java
@@ -47,6 +47,8 @@ public final class ConfigHandler {
     public static int netherDimensionID;
     public static int endDimensionID;
     public static int bedrockDimensionID = 19;
+    public static boolean shouldKamiLegsDoLightFeature = false;
+    public static boolean shouldKamiBootsDoGrass = true;
 
     public static int soulHeartHeight;
 
@@ -228,6 +230,16 @@ public final class ConfigHandler {
                     -1023,
                     1023,
                     "The Dimension ID for the End, leave at 1 if you don't modify it with another mod/plugin.");
+            shouldKamiLegsDoLightFeature = config.getBoolean(
+                    "Kami Leggings Light Placing Feature Enabled",
+                    "general.kami",
+                    shouldKamiLegsDoLightFeature,
+                    "Sets if Legs of the Burning Mantle (Awakened Kami leggings) will do the effect where it places lights near you.");
+            shouldKamiBootsDoGrass = config.getBoolean(
+                    "Kami Boots Dirt into Grass Feature Enabled",
+                    "general.kami",
+                    shouldKamiBootsDoGrass,
+                    "Sets if Boots of the Horizontal Shield (Awakened Kami Boots) will do the effect where dirt under you turns into grass.");
         }
 
         LibEnchantIDs.idAscentBoost = loadEnchant(LibEnchantNames.ASCENT_BOOST, LibEnchantIDs.idAscentBoost);

--- a/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemGemBoots.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemGemBoots.java
@@ -67,11 +67,13 @@ public class ItemGemBoots extends ItemIchorclothArmorAdv {
         player.jumpMovementFactor = player.isSprinting() ? 0.05F : 0.04F;
         player.fallDistance = 0F;
 
-        int x = (int) player.posX;
-        int y = (int) player.posY - 1;
-        int z = (int) player.posZ;
-        if (player.worldObj.getBlock(x, y, z) == Blocks.dirt && player.worldObj.getBlockMetadata(x, y, z) == 0)
-            player.worldObj.setBlock(x, y, z, Blocks.grass, 0, 2);
+        if (ConfigHandler.shouldKamiBootsDoGrass) {
+            int x = (int) player.posX;
+            int y = (int) player.posY - 1;
+            int z = (int) player.posZ;
+            if (player.worldObj.getBlock(x, y, z) == Blocks.dirt && player.worldObj.getBlockMetadata(x, y, z) == 0)
+                player.worldObj.setBlock(x, y, z, Blocks.grass, 0, 2);
+        }
     }
 
     @Override

--- a/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemGemLegs.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemGemLegs.java
@@ -85,7 +85,9 @@ public class ItemGemLegs extends ItemIchorclothArmorAdv {
 
             if (player.isBurning()) player.heal(0.5F);
             addPotionEffect(player, Potion.fireResistance, 119, -1);
-            setNearBrightNitor(player);
+            if (ConfigHandler.shouldKamiLegsDoLightFeature) {
+                setNearBrightNitor(player);
+            }
         }
     }
 


### PR DESCRIPTION
1. Kami/Ichor Leggings have had the "produce light" ability config'ed and disabled by default.
2. Kami/Ichor boots have had the "dirt into grass" ability config'ed but left enabled by default.

Just let me know if the general consensus would be that the dirt into grass should also be disabled by default and I'll swap that to default to false as well.

Tested both configs as true/false in Singleplayer for both abilities to ensure they work/don't work properly.