### PR TITLE
Fixed crashes upon harvesting of Praecantatio Infused Seeds

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.27'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.30'
 }
 
 

--- a/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
@@ -208,7 +208,6 @@ public class AspectCropLootManager {
 
         addAspectLoot(Aspect.ENERGY, new ItemStack(ConfigItems.itemResource, 12));
 
-        // addAspectLoot(Aspect.MAGIC, "materialAspectShard");		//produces crash, replaced by adding the shards directly
         addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 0));
         addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 1));
         addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 2));

--- a/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
@@ -208,7 +208,14 @@ public class AspectCropLootManager {
 
         addAspectLoot(Aspect.ENERGY, new ItemStack(ConfigItems.itemResource, 12));
 
-        addAspectLoot(Aspect.MAGIC, "materialAspectShard");
+        // addAspectLoot(Aspect.MAGIC, "materialAspectShard");		//produces crash, replaced by adding the shards directly
+        addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 0));
+        addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 1));
+        addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 2));
+        addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 3));
+        addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 4));
+        addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 5));
+        addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 6));
 
         addAspectLoot(Aspect.HEAL, new ItemStack(Items.golden_apple));
 


### PR DESCRIPTION
Fixed a bug that causes crashes upon harvesting of  Praecantatio Infused Seeds

Praecantatio Infused Seeds had their loot set to be any item that contains "materialAspectShard" in their oreDic. This causes the game to crash upon generating loot of this crop for unknown reasons.
This PR removes this bug by individually adding the respective items.
The crop will now drop any of the base Thaumcraft shards.
Should Forbidden Magic Shards (Envy, Wrath, etc.) be included in this? The original code would not have found those either.

Signed-off-by: ClassixX <30446897+ClassixX@users.noreply.github.com>