### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/ttinkerer/lang/en_US.lang
+++ b/src/main/resources/assets/ttinkerer/lang/en_US.lang
@@ -101,6 +101,7 @@ item.mobAspect.name=Soul Aspect
 item.mobAspect.condensed.name=Condensed Soul Aspect
 item.mobAspect.infused.name=Infused Soul Aspect
 item.infusedSeeds.name=Infused Seeds
+item.infusedPotion.name=Potion
 item.infusedPotion.Aer.name=Potion of Aer
 item.infusedPotion.Ignis.name=Potion of Ignis
 item.infusedPotion.Terra.name=Potion of Terra
@@ -152,7 +153,12 @@ tile.travelSlab.name=Paving Slab of Travel
 tile.travelSlabFull.name=Paving Slab of Travel
 tile.travelStairs.name=Paving Stair of Travel
 tile.wardSlab.name=Paving Slab of Warding
+tile.wardSlabFull.name=Paving Slab of Warding
 tile.infusedFarmland.name=Infused Farmland
+tile.gaseousLight.name=Gaseous Light
+tile.gaseousShadow.name=Gaseous Shadow
+tile.infusedGrainBlock.name=Imbued Grain
+tile.nitorGas.name=Nitor Gas
 
 # Fire
 tile.fireWater.name=Aqua Imbued Fire


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.