### PR TITLE
Essentia Funnel Bugfix

### DIFF
--- a/src/main/java/thaumic/tinkerer/client/render/tile/RenderTileFunnel.java
+++ b/src/main/java/thaumic/tinkerer/client/render/tile/RenderTileFunnel.java
@@ -11,6 +11,8 @@
  */
 package thaumic.tinkerer.client.render.tile;
 
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -20,6 +22,7 @@ import org.lwjgl.opengl.GL11;
 
 import thaumcraft.client.renderers.block.BlockJarRenderer;
 import thaumcraft.client.renderers.tile.ItemJarFilledRenderer;
+import thaumcraft.common.config.ConfigBlocks;
 import thaumic.tinkerer.common.block.tile.TileFunnel;
 
 public class RenderTileFunnel extends TileEntitySpecialRenderer {
@@ -34,12 +37,12 @@ public class RenderTileFunnel extends TileEntitySpecialRenderer {
         if (stack != null) {
             GL11.glPushMatrix();
             GL11.glTranslated(d0 + 0.5, d1 + 0.365, d2 + 0.5);
-            // if(Block.getBlockFromItem(stack.getItem())== ConfigBlocks.blockJar) {
-            // GL11.glTranslatef(0F, 0.25F, 0F);
-            // jarRenderer.renderInventoryBlock(ConfigBlocks.blockJar, 0, 0, new RenderBlocks());
-            // }
-            // else
-            jarRenderer1.renderItem(IItemRenderer.ItemRenderType.ENTITY, stack, (Object[]) null);
+            if (Block.getBlockFromItem(stack.getItem()) == ConfigBlocks.blockJar) {
+                GL11.glTranslatef(0F, 0.25F, 0F);
+                jarRenderer.renderInventoryBlock(ConfigBlocks.blockJar, stack.getItemDamage(), 0, new RenderBlocks());
+            } else {
+                jarRenderer1.renderItem(IItemRenderer.ItemRenderType.ENTITY, stack, (Object[]) null);
+            }
             GL11.glPopMatrix();
         }
     }

--- a/src/main/java/thaumic/tinkerer/common/block/tile/TileFunnel.java
+++ b/src/main/java/thaumic/tinkerer/common/block/tile/TileFunnel.java
@@ -31,6 +31,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.aspects.IAspectContainer;
 import thaumcraft.api.aspects.IEssentiaContainerItem;
 import thaumcraft.common.blocks.ItemJarFilled;
+import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.tiles.TileJarFillable;
 import thaumcraft.common.tiles.TileJarFillableVoid;
 import thaumic.tinkerer.common.lib.LibBlockNames;
@@ -51,7 +52,7 @@ public class TileFunnel extends TileEntity implements ISidedInventory, IAspectCo
                     Aspect aspect = aspectList.getAspects()[0];
 
                     TileEntity tile = worldObj.getTileEntity(xCoord, yCoord - 1, zCoord);
-                    if (tile != null && tile instanceof TileEntityHopper) {
+                    if (tile instanceof TileEntityHopper) {
                         TileEntity tile1 = getHopperFacing(
                                 tile.xCoord,
                                 tile.yCoord,
@@ -68,6 +69,18 @@ public class TileFunnel extends TileEntity implements ISidedInventory, IAspectCo
                                             && (aspectList1.getAmount(aspectList1.getAspects()[0]) < 64 || voidJar)) {
                                 jar1.addToContainer(aspect, 1);
                                 item.setAspects(jar, aspectList.remove(aspect, 1));
+                            }
+                            // "AspectFilter" is used for the jar label
+                            if (aspectList.getAmount(aspectList.getAspects()[0]) == 0
+                                    && !jar.stackTagCompound.hasKey("AspectFilter")) {
+                                String itemName = jar.getUnlocalizedName();
+                                if (itemName.equals("item.BlockJarFilledItem")) {
+                                    setInventorySlotContents(0, new ItemStack(ConfigBlocks.blockJar));
+                                } else if (itemName.equals("item.BlockJarFilledItem.void")) {
+                                    setInventorySlotContents(0, new ItemStack(ConfigBlocks.blockJar));
+                                    getStackInSlot(0).setItemDamage(3);
+                                }
+                                this.markDirty();
                             }
                         }
                     }


### PR DESCRIPTION
Fix a bug where the essentia funnel would leave an empty "(Void) Jar of Essentia" item instead of giving an empty warded/void jar.
Also readd rendering for empty warded/void jars inside of the funnel.