### PR TITLE
Added AE2 API modid to the required section in @Mod annotation.

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/lib/LibMisc.java
+++ b/src/main/java/thaumic/tinkerer/common/lib/LibMisc.java
@@ -21,7 +21,7 @@ public final class LibMisc {
 
     public static final String NETWORK_CHANNEL = MOD_ID;
 
-    public static final String DEPENDENCIES = "required-after:Forge@[10.12.1.1112,);required-after:Thaumcraft;before:advthaum;after:IC2;after:Waila;after:ForgeMultipart;after:ComputerCraft";
+    public static final String DEPENDENCIES = "required-after:Forge@[10.12.1.1112,);required-after:Thaumcraft;before:advthaum;required-after:appliedenergistics2|API;after:IC2;after:Waila;after:ForgeMultipart;after:ComputerCraft";
 
     public static final String COMMON_PROXY = "thaumic.tinkerer.common.core.proxy.TTCommonProxy";
     public static final String CLIENT_PROXY = "thaumic.tinkerer.client.core.proxy.TTClientProxy";


### PR DESCRIPTION
It's a very small change, but the regular Thaumic Tinkerer has the API embedded - this one crashes when the api is not present and it's quite confusing.