### PR TITLE
delete gaia missile instead of repath it

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/item/foci/ItemFocusDeflect.java
+++ b/src/main/java/thaumic/tinkerer/common/item/foci/ItemFocusDeflect.java
@@ -96,7 +96,7 @@ public class ItemFocusDeflect extends ItemModFocus {
     private static void checkBotaniaMagicMissile(Entity e) {
         if (!Loader.isModLoaded("Botania")) return;
         if (e instanceof EntityMagicMissile) {
-            ((EntityMagicMissile) e).setTarget(null);
+            e.setDead();
         }
     }
 


### PR DESCRIPTION
#48 didn't really work. (see https://discord.com/channels/181078474394566657/603348502637969419/1365245689357144075) Gaia missiles will try to find another target in range if we manually override its target to null, and we have no way to exempt the current player from that list beyond moving the gaia missile further out. However, the gaia missile has an absurd targeting radius of 12 blocks, so if we go down this path, this making it effectively out of the entire combat arena.. I guess we might as well just delete it. It'd also save us the computation needed to find out how much more the gaia missile needs to be moved.  