### PR TITLE
Fixed Wand Focus: Dislocation issue

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/item/foci/ItemFocusDislocation.java
+++ b/src/main/java/thaumic/tinkerer/common/item/foci/ItemFocusDislocation.java
@@ -117,7 +117,7 @@ public class ItemFocusDislocation extends ItemModFocus {
                                 stack.getItemDamage(),
                                 1 | 2);
                         ((ItemBlock) stack.getItem()).field_150939_a
-                                .onBlockPlacedBy(world, mop.blockX, mop.blockY, mop.blockZ, player, itemstack);
+                                .onBlockPlacedBy(world, mop.blockX, mop.blockY, mop.blockZ, player, stack);
                         NBTTagCompound tileCmp = getStackTileEntity(itemstack);
                         if (tileCmp != null && !tileCmp.hasNoTags()) {
                             TileEntity tile1 = TileEntity.createAndLoadEntity(tileCmp);


### PR DESCRIPTION
A careless implementation in the Wand Focus: Dislocation code resulted in the wand being incorrectly passed as the item parameter to onBlockPlacedBy. 

As a result, the block's metadata was set to that of the wand instead of the intended item.