### PR TITLE
Allow Bottomless Pouch in Focus Pouch slot

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/item/kami/ItemIchorPouch.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/ItemIchorPouch.java
@@ -58,7 +58,7 @@ import thaumic.tinkerer.common.research.ResearchHelper;
 @Optional.Interface(iface = "baubles.api.expanded.IBaubleExpanded", modid = "Baubles|Expanded")
 public class ItemIchorPouch extends ItemFocusPouch implements IBauble, IBaubleExpanded, ITTinkererItem {
 
-    private static boolean baublesExpandedLoaded = Loader.isModLoaded("Baubles|Expanded");
+    private static final boolean baublesExpandedLoaded = Loader.isModLoaded("Baubles|Expanded");
 
     public ItemIchorPouch() {
         super();
@@ -123,6 +123,7 @@ public class ItemIchorPouch extends ItemFocusPouch implements IBauble, IBaubleEx
     }
 
     @Override
+    @Optional.Method(modid = "Baubles|Expanded")
     public String[] getBaubleTypes(ItemStack itemstack) {
         return new String[] { "belt", "focus_pouch" };
     }

--- a/src/main/java/thaumic/tinkerer/common/item/kami/ItemIchorPouch.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/ItemIchorPouch.java
@@ -12,6 +12,7 @@
 package thaumic.tinkerer.common.item.kami;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
@@ -27,6 +28,10 @@ import net.minecraftforge.common.util.Constants;
 
 import baubles.api.BaubleType;
 import baubles.api.IBauble;
+import baubles.api.expanded.BaubleItemHelper;
+import baubles.api.expanded.IBaubleExpanded;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import thaumcraft.api.aspects.Aspect;
@@ -50,7 +55,10 @@ import thaumic.tinkerer.common.research.IRegisterableResearch;
 import thaumic.tinkerer.common.research.KamiResearchItem;
 import thaumic.tinkerer.common.research.ResearchHelper;
 
-public class ItemIchorPouch extends ItemFocusPouch implements IBauble, ITTinkererItem {
+@Optional.Interface(iface = "baubles.api.expanded.IBaubleExpanded", modid = "Baubles|Expanded")
+public class ItemIchorPouch extends ItemFocusPouch implements IBauble, IBaubleExpanded, ITTinkererItem {
+
+    private static boolean baublesExpandedLoaded = Loader.isModLoaded("Baubles|Expanded");
 
     public ItemIchorPouch() {
         super();
@@ -82,22 +90,41 @@ public class ItemIchorPouch extends ItemFocusPouch implements IBauble, ITTinkere
 
     @Override
     public ItemStack[] getInventory(ItemStack item) {
-        ItemStack[] stackList = new ItemStack[13 * 9];
-        if (item.hasTagCompound()) {
-            NBTTagList var2 = item.stackTagCompound.getTagList("Inventory", Constants.NBT.TAG_COMPOUND);
-            for (int var3 = 0; var3 < var2.tagCount(); var3++) {
-                NBTTagCompound var4 = var2.getCompoundTagAt(var3);
-                int var5 = var4.getByte("Slot") & 0xFF;
-                if (var5 >= 0 && var5 < stackList.length) stackList[var5] = ItemStack.loadItemStackFromNBT(var4);
+        ItemStack[] inventory = new ItemStack[13 * 9];
+        if (!item.hasTagCompound()) {
+            return inventory;
+        }
+
+        NBTTagList tagList = item.stackTagCompound.getTagList("Inventory", Constants.NBT.TAG_COMPOUND);
+
+        for (int i = 0; i < tagList.tagCount(); i++) {
+            NBTTagCompound tag = tagList.getCompoundTagAt(i);
+            int slot = tag.getByte("Slot") & 0xFF;
+
+            if (slot < inventory.length) {
+                inventory[slot] = ItemStack.loadItemStackFromNBT(tag);
             }
         }
 
-        return stackList;
+        return inventory;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void addInformation(ItemStack is, EntityPlayer player, List textLines, boolean showAdvancedInfo) {
+        if (baublesExpandedLoaded) {
+            BaubleItemHelper.addSlotInformation(textLines, getBaubleTypes(null));
+        }
     }
 
     @Override
     public BaubleType getBaubleType(ItemStack itemstack) {
         return BaubleType.BELT;
+    }
+
+    @Override
+    public String[] getBaubleTypes(ItemStack itemstack) {
+        return new String[] { "belt", "focus_pouch" };
     }
 
     @Override

--- a/src/main/resources/assets/ttinkerer/lang/en_US.lang
+++ b/src/main/resources/assets/ttinkerer/lang/en_US.lang
@@ -557,7 +557,7 @@ ttresearch.page.ICHOR_SWORD_GEM.1=Soul Hearts are hearts that can only be used o
 # -- BOTTOMLESS POUCH
 ttresearch.name.ICHOR_POUCH=Bottomless Pouch
 ttresearch.lore.ICHOR_POUCH=Try not to tear it
-ttresearch.page.ICHOR_POUCH.0=By infusing a Focus Pouch with items such as the Portable Hole focus, you managed to allow it to not only store more than Foci, but also to have a very extensive storage space.<BR><BR>This pouch can not only carry more than four chests, but it also doubles as a standard Focus Pouch, allowing any foci within it to be inserted in a wand like normally. You can kiss your inventory problems goodbye.
+ttresearch.page.ICHOR_POUCH.0=By infusing a Focus Pouch with items such as the Portable Hole focus, you’ve enhanced it to store not just foci, but any kind of items with an impressively spacious interior.<BR><BR>This upgraded pouch can hold the contents of more than four chests, all while functioning as a regular Focus Pouch, allowing any foci inside to be equipped to a wand as usual. It even fits in the Focus Pouch bauble slot added by the Salis Arcana mod. You can kiss your inventory problems goodbye.
 
 # -- BLACK HOLE RING
 ttresearch.name.BLOCK_TALISMAN=Black Hole Ring

--- a/src/main/resources/assets/ttinkerer/lang/en_US.lang
+++ b/src/main/resources/assets/ttinkerer/lang/en_US.lang
@@ -557,7 +557,7 @@ ttresearch.page.ICHOR_SWORD_GEM.1=Soul Hearts are hearts that can only be used o
 # -- BOTTOMLESS POUCH
 ttresearch.name.ICHOR_POUCH=Bottomless Pouch
 ttresearch.lore.ICHOR_POUCH=Try not to tear it
-ttresearch.page.ICHOR_POUCH.0=By infusing a Focus Pouch with items such as the Portable Hole focus, you’ve enhanced it to store not just foci, but any kind of items with an impressively spacious interior.<BR><BR>This upgraded pouch can hold the contents of more than four chests, all while functioning as a regular Focus Pouch, allowing any foci inside to be equipped to a wand as usual. It even fits in the Focus Pouch bauble slot added by the Salis Arcana mod. You can kiss your inventory problems goodbye.
+ttresearch.page.ICHOR_POUCH.0=By infusing a Focus Pouch with items such as the Portable Hole focus, you’ve enhanced it to store not just foci, but any kind of items with an impressively spacious interior.<BR><BR>This upgraded pouch can hold the contents of more than four chests, all while functioning as a regular Focus Pouch, allowing any foci inside to be equipped to a wand as usual. You can kiss your inventory problems goodbye.
 
 # -- BLACK HOLE RING
 ttresearch.name.BLOCK_TALISMAN=Black Hole Ring


### PR DESCRIPTION
Slot is added by Salis Arcana. Does not register the slot itself if the mod is missing, since the regular focus pouch wouldn't be able to be worn in it and that would be weird. It also probably wouldn't even be functional without Salis since it adds a bunch of mixins for Thaum to use BE's slots.

<img width="574" height="398" alt="image" src="https://github.com/user-attachments/assets/1d9cd9e5-3b7d-4ca5-8769-43b05f3fd248" />
<img width="972" height="265" alt="image" src="https://github.com/user-attachments/assets/fee6ad34-a527-499e-8cee-2e9823096817" />

"Focus Pouch" not being green is an issue with Salis that I will make another PR for.
Foci are pulled from both as expected.