### PR TITLE
Item Placement Mirror Fixes

### DIFF
--- a/src/main/java/thaumic/tinkerer/client/core/handler/kami/PlacementMirrorPredictionRenderer.java
+++ b/src/main/java/thaumic/tinkerer/client/core/handler/kami/PlacementMirrorPredictionRenderer.java
@@ -8,7 +8,6 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.world.World;
@@ -17,63 +16,54 @@ import net.minecraftforge.client.event.RenderWorldLastEvent;
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import thaumic.tinkerer.common.ThaumicTinkerer;
 import thaumic.tinkerer.common.item.kami.ItemPlacementMirror;
+import thaumic.tinkerer.common.registry.TTRegistry;
 
 public final class PlacementMirrorPredictionRenderer {
 
-    RenderBlocks blockRender = new RenderBlocks();
+    private final RenderBlocks blockRender;
+
+    public PlacementMirrorPredictionRenderer() {
+        this.blockRender = new RenderBlocks();
+        blockRender.useInventoryTint = false;
+    }
 
     @SubscribeEvent
     public void onWorldRenderLast(RenderWorldLastEvent event) {
-
         World world = Minecraft.getMinecraft().theWorld;
         List<EntityPlayer> playerEntities = world.playerEntities;
         for (EntityPlayer player : playerEntities) {
             ItemStack currentStack = player.getCurrentEquippedItem();
-            if (currentStack != null
-                    && currentStack.getItem()
-                            == ThaumicTinkerer.registry.getFirstItemFromClass(ItemPlacementMirror.class)
-                    && ItemPlacementMirror.getBlock(currentStack) != Blocks.air) {
+            if (currentStack != null && currentStack.getItem() == TTRegistry.itemPlacementMirror) {
                 renderPlayerLook(player, currentStack);
             }
         }
     }
 
     private void renderPlayerLook(EntityPlayer player, ItemStack stack) {
-        ChunkCoordinates[] coords = ItemPlacementMirror.getBlocksToPlace(stack, player);
-        if (ItemPlacementMirror.hasBlocks(stack, player, coords)) {
-            ItemStack block = new ItemStack(
-                    ItemPlacementMirror.getBlock(stack),
-                    1,
-                    ItemPlacementMirror.getBlockMeta(stack));
-            ChunkCoordinates lastCoords = new ChunkCoordinates(0, 0, 0);
-
-            GL11.glPushMatrix();
+        Block requiredBlock = ItemPlacementMirror.getBlock(stack);
+        if (requiredBlock == null) return;
+        int requiredMetadata = ItemPlacementMirror.getBlockMeta(stack);
+        List<ChunkCoordinates> coords = ItemPlacementMirror.getBlocksToPlace(stack, player);
+        if (ItemPlacementMirror.hasBlocks(player, requiredBlock, requiredMetadata, coords.size())) {
             GL11.glEnable(GL11.GL_BLEND);
             GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-
+            GL11.glColor4f(1F, 1F, 1F, 0.6F);
+            Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.locationBlocksTexture);
             for (ChunkCoordinates coord : coords) {
-                renderBlockAt(block, coord, lastCoords);
-                lastCoords = coord;
+                renderBlockAt(requiredBlock, requiredMetadata, coord);
             }
-            GL11.glPopMatrix();
+            GL11.glColor4f(1F, 1F, 1F, 1F);
         }
     }
 
-    private void renderBlockAt(ItemStack block, ChunkCoordinates pos, ChunkCoordinates last) {
-        if (block.getItem() == null) return;
+    private void renderBlockAt(Block block, int metadata, ChunkCoordinates pos) {
         GL11.glPushMatrix();
         GL11.glTranslated(
                 pos.posX + 0.5 - RenderManager.renderPosX,
                 pos.posY + 0.5 - RenderManager.renderPosY,
                 pos.posZ + 0.5 - RenderManager.renderPosZ);
-
-        GL11.glColor4f(1F, 1F, 1F, 0.6F);
-        Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.locationBlocksTexture);
-        blockRender.useInventoryTint = false;
-        blockRender.renderBlockAsItem(Block.getBlockFromItem(block.getItem()), block.getItemDamage(), 1F);
-
+        blockRender.renderBlockAsItem(block, metadata, 1F);
         GL11.glPopMatrix();
     }
 }

--- a/src/main/java/thaumic/tinkerer/client/render/item/RenderGenericSeeds.java
+++ b/src/main/java/thaumic/tinkerer/client/render/item/RenderGenericSeeds.java
@@ -3,7 +3,6 @@ package thaumic.tinkerer.client.render.item;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
@@ -18,8 +17,6 @@ import thaumic.tinkerer.common.item.ItemInfusedSeeds;
  * Created by pixlepix on 8/6/14.
  */
 public class RenderGenericSeeds implements IItemRenderer {
-
-    private static RenderItem renderItem = new RenderItem();
 
     @Override
     public boolean handleRenderType(ItemStack item, ItemRenderType type) {

--- a/src/main/java/thaumic/tinkerer/client/render/item/RenderMobDisplay.java
+++ b/src/main/java/thaumic/tinkerer/client/render/item/RenderMobDisplay.java
@@ -2,7 +2,6 @@ package thaumic.tinkerer.client.render.item;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.entity.Render;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
@@ -15,8 +14,6 @@ import thaumic.tinkerer.common.core.helper.EnumMobAspect;
 import thaumic.tinkerer.common.item.ItemMobDisplay;
 
 public class RenderMobDisplay implements IItemRenderer {
-
-    private static RenderItem renderItem = new RenderItem();
 
     @Override
     public boolean handleRenderType(ItemStack itemStack, ItemRenderType itemRenderType) {

--- a/src/main/java/thaumic/tinkerer/client/render/item/kami/RenderPlacementMirror.java
+++ b/src/main/java/thaumic/tinkerer/client/render/item/kami/RenderPlacementMirror.java
@@ -1,9 +1,7 @@
 package thaumic.tinkerer.client.render.item.kami;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.client.IItemRenderer;
@@ -14,9 +12,6 @@ import thaumic.tinkerer.common.ThaumicTinkerer;
 import thaumic.tinkerer.common.item.kami.ItemPlacementMirror;
 
 public class RenderPlacementMirror implements IItemRenderer {
-
-    RenderItem render = new RenderItem();
-    ItemRenderer renderer = new ItemRenderer(Minecraft.getMinecraft());
 
     @Override
     public boolean handleRenderType(ItemStack item, ItemRenderType type) {
@@ -69,6 +64,7 @@ public class RenderPlacementMirror implements IItemRenderer {
                 break;
             }
             case INVENTORY: {
+                GL11.glEnable(GL11.GL_ALPHA_TEST);
                 GL11.glPushMatrix();
                 GL11.glRotatef(45f, 0f, 1f, 0f);
                 GL11.glScalef(1.5f, 1.8f, 1.8f);
@@ -77,6 +73,7 @@ public class RenderPlacementMirror implements IItemRenderer {
 
                 renderItem(ItemRenderType.EQUIPPED, item, data);
                 GL11.glPopMatrix();
+                GL11.glDisable(GL11.GL_ALPHA_TEST);
                 break;
             }
             default:

--- a/src/main/java/thaumic/tinkerer/common/item/kami/ItemPlacementMirror.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/ItemPlacementMirror.java
@@ -206,8 +206,7 @@ public class ItemPlacementMirror extends ItemKamiBase {
                 return;
             }
 
-            if (stackInSlot != null
-                    && stackInSlot.getItem() == TTRegistry.itemBlackHoleTalisman)
+            if (stackInSlot != null && stackInSlot.getItem() == TTRegistry.itemBlackHoleTalisman)
                 talismansToCheck.add(stackInSlot);
         }
 

--- a/src/main/java/thaumic/tinkerer/common/item/kami/ItemPlacementMirror.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/ItemPlacementMirror.java
@@ -166,10 +166,10 @@ public class ItemPlacementMirror extends ItemKamiBase {
     }
 
     public void placeAllBlocks(ItemStack stack, EntityPlayer player) {
-        List<ChunkCoordinates> blocksToPlace = getBlocksToPlace(stack, player);
         Block requiredBlock = getBlock(stack);
         if (requiredBlock == null) return;
         int requiredMetadata = getBlockMeta(stack);
+        List<ChunkCoordinates> blocksToPlace = getBlocksToPlace(stack, player);
         if (!hasBlocks(player, requiredBlock, requiredMetadata, blocksToPlace.size())) return;
 
         ItemStack stackToPlace = new ItemStack(requiredBlock, 1, requiredMetadata);

--- a/src/main/java/thaumic/tinkerer/common/item/kami/ItemPlacementMirror.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/ItemPlacementMirror.java
@@ -61,6 +61,7 @@ public class ItemPlacementMirror extends ItemKamiBase {
         Item requiredItem = Item.getItemFromBlock(requiredBlock);
 
         int current = 0;
+        List<ItemStack> talismansToCheck = new ArrayList<>();
         for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
             ItemStack stackInSlot = player.inventory.getStackInSlot(i);
             if (stackInSlot == null) continue;
@@ -73,10 +74,14 @@ public class ItemPlacementMirror extends ItemKamiBase {
             } else if (itemInSlot == TTRegistry.itemBlackHoleTalisman) {
                 if (ItemBlockTalisman.getBlock(stackInSlot) == requiredBlock
                         && ItemBlockTalisman.getBlockMeta(stackInSlot) == requiredMetadata) {
-                    current += ItemBlockTalisman.getBlockCount(stackInSlot);
-                    if (current >= requiredAmount) return true;
+                    talismansToCheck.add(stackInSlot);
                 }
             }
+        }
+        for (ItemStack talisman : talismansToCheck) {
+            current += ItemBlockTalisman.getBlockCount(talisman);
+
+            if (current >= requiredAmount) return true;
         }
         return false;
     }

--- a/src/main/java/thaumic/tinkerer/common/registry/TTRegistry.java
+++ b/src/main/java/thaumic/tinkerer/common/registry/TTRegistry.java
@@ -21,6 +21,8 @@ import cpw.mods.fml.relauncher.Side;
 import thaumic.tinkerer.client.lib.LibResources;
 import thaumic.tinkerer.common.ThaumicTinkerer;
 import thaumic.tinkerer.common.core.handler.ModCreativeTab;
+import thaumic.tinkerer.common.item.kami.ItemBlockTalisman;
+import thaumic.tinkerer.common.item.kami.ItemPlacementMirror;
 import thaumic.tinkerer.common.research.IRegisterableResearch;
 
 public class TTRegistry {
@@ -30,6 +32,9 @@ public class TTRegistry {
 
     private ArrayList<Class> blockClasses = new ArrayList<>();
     private HashMap<Class, ArrayList<Block>> blockRegistry = new HashMap<>();
+
+    public static Item itemPlacementMirror;
+    public static Item itemBlackHoleTalisman;
 
     public void registerClasses() {
         try {
@@ -171,6 +176,9 @@ public class TTRegistry {
                 }
             }
         }
+
+        itemBlackHoleTalisman = getFirstItemFromClass(ItemBlockTalisman.class);
+        itemPlacementMirror = getFirstItemFromClass(ItemPlacementMirror.class);
     }
 
     public ArrayList<Item> getItemFromClass(Class clazz) {


### PR DESCRIPTION
The placement mirror has several bugs (one of them locked me out of my test world lmao), a rendering issue where the item renderer is missing alpha test and creates a lot of unnecessary objects in its rendering. This PR fixes all of that.

Tested in game and it seems to work flawlessly.