### PR TITLE
Fix failed build tests

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -19,7 +19,7 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:CodeChickenCore:1.4.7:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.11.19-GTNH:api') {transitive=false}
     compileOnly('net.industrial-craft:industrialcraft-2:2.2.828-experimental:api') {transitive=false}
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.456:dev") {transitive=false}
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.457:dev") {transitive=false}
     compileOnly('curse.maven:computercraft-67504:2269339')
     compileOnly('curse.maven:cofh-core-69162:2388751')
 

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,4 +1,15 @@
 // Add any additional repositories for your dependencies here
 
 repositories {
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = 'glease'
+                url = 'https://maven.glease.net/repos/releases/'
+            }
+        }
+        filter {
+            includeGroup('net.glease')
+        }
+    }
 }


### PR DESCRIPTION
Any repo that depends on `TCNEIAdditions:1.5.4` or higher requires the maven of glease to properly build (this was briefly talked about [here](https://discord.com/channels/181078474394566657/939305179524792340/1418058079857021009)). If you'd like to get it uploaded to gtnh maven, contact glease.