### PR TITLE
Allow the Talisman of Remedium to be repaired with Smokey Quartz

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
+++ b/src/main/java/thaumic/tinkerer/common/item/ItemCleansingTalisman.java
@@ -292,4 +292,12 @@ public class ItemCleansingTalisman extends ItemBase implements IBauble {
     public String getItemName() {
         return LibItemNames.CLEANSING_TALISMAN;
     }
+
+    @Override
+    public boolean getIsRepairable(ItemStack talisman, ItemStack material) {
+        if (material != null
+                && material.getItem() == ThaumicTinkerer.registry.getFirstItemFromClass(ItemDarkQuartz.class))
+            return true;
+        return super.getIsRepairable(talisman, material);
+    }
 }


### PR DESCRIPTION
Smokey Quartz is the main ingredient used when crafting this item.

This lets it be repaired in an anvil and have Timeless Ivy from Botania applied to it (it slowly repairs the item using mana like mana material gear and costs three of the repair material to apply).