### PR TITLE
Fix wrong stack sizes for ichor recipe

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/item/kami/ItemKamiResource.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/ItemKamiResource.java
@@ -218,9 +218,9 @@ public class ItemKamiResource extends ItemKamiBase {
                         new AspectList().add(Aspect.MAN, 32).add(Aspect.LIGHT, 32).add(Aspect.SOUL, 64),
                         new ItemStack(Items.nether_star),
                         new ItemStack(Items.diamond),
-                        new ItemStack(this, 8, 7),
+                        new ItemStack(this, 1, 7),
                         new ItemStack(Items.ender_eye),
-                        new ItemStack(this, 8, 6)),
+                        new ItemStack(this, 1, 6)),
                 new ThaumicTinkererInfusionRecipe(
                         LibResearch.KEY_ICHORCLOTH_ROD,
                         new ItemStack(this, 1, 5),


### PR DESCRIPTION
Fixes this visual bug in NEI (the recipe only ever needed 1 of each and the recipe displayed properly in the Thaumonomicon)
<img width="573" height="802" alt="image" src="https://github.com/user-attachments/assets/c052eb70-4eba-4116-b3f0-70edc1aaec0f" />