### PR TITLE
Use golden leggings for ichor leggings recipe

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemGemLegs.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemGemLegs.java
@@ -127,7 +127,7 @@ public class ItemGemLegs extends ItemIchorclothArmorAdv {
                 new ItemStack(ThaumicTinkerer.registry.getFirstItemFromClass(ItemKamiResource.class)),
                 new ItemStack(ConfigItems.itemFocusPrimal),
                 new ItemStack(ConfigItems.itemThaumonomicon),
-                new ItemStack(Items.golden_chestplate),
+                new ItemStack(Items.golden_leggings),
                 new ItemStack(Items.potionitem, 1, 8195),
                 new ItemStack(ThaumicTinkerer.registry.getFirstItemFromClass(ItemFocusSmelt.class)),
                 new ItemStack(ThaumicTinkerer.registry.getFirstItemFromClass(ItemBrightNitor.class)),


### PR DESCRIPTION
Likely copy pasted from the chestplate recipe, now it uses the right armor piece for the default recipe. GTNH recipe is fine and doesn't need to be changed.