### PR TITLE
Awakened Ichorium Pickaxe Fixes

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
@@ -105,13 +105,10 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
         ForgeDirection direction = ForgeDirection.getOrientation(block.sideHit);
         int fortune = EnchantmentHelper.getFortuneModifier(player);
         boolean silk = EnchantmentHelper.getSilkTouchModifier(player);
-        if (ConfigHandler.bedrockDimensionID != 0 && blk == Blocks.bedrock
-                && ((world.provider.isSurfaceWorld() && y < 5)
-                        || (y > 253 && world.provider instanceof WorldProviderBedrock))) {
+        if (ConfigHandler.bedrockDimensionID != 0 && blk == Blocks.bedrock && ((world.provider.isSurfaceWorld() && y < 5) || (y > 253 && world.provider instanceof WorldProviderBedrock))) {
             world.setBlock(x, y, z, ThaumicTinkerer.registry.getFirstBlockFromClass(BlockBedrockPortal.class));
         }
-        if (ConfigHandler.bedrockDimensionID != 0 && blk == Blocks.bedrock
-                && (y <= 253 && world.provider instanceof WorldProviderBedrock)) {
+        if (ConfigHandler.bedrockDimensionID != 0 && blk == Blocks.bedrock && (y <= 253 && world.provider instanceof WorldProviderBedrock)) {
             world.setBlock(x, y, z, Blocks.air);
         }
         switch (ToolHandler.getMode(stack)) {

--- a/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
@@ -110,8 +110,13 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
             if (ConfigHandler.bedrockDimensionID != 0) {
                 // Bedrock → Portal (Overworld low Y OR Bedrock dimension high Y)
                 if (blk == Blocks.bedrock) {
-                    if ((world.provider.isSurfaceWorld() && y < 5) || (y > 253 && world.provider instanceof WorldProviderBedrock)) {
-                        world.setBlock(x, y, z, ThaumicTinkerer.registry.getFirstBlockFromClass(BlockBedrockPortal.class));
+                    if ((world.provider.isSurfaceWorld() && y < 5)
+                            || (y > 253 && world.provider instanceof WorldProviderBedrock)) {
+                        world.setBlock(
+                                x,
+                                y,
+                                z,
+                                ThaumicTinkerer.registry.getFirstBlockFromClass(BlockBedrockPortal.class));
                     }
 
                     // Bedrock → Air (Bedrock dimension normal Y)
@@ -132,21 +137,21 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
 
                 if (!player.isSneaking()) {
                     ToolHandler.removeBlocksInIteration(
-                        player,
-                        world,
-                        x,
-                        y,
-                        z,
-                        doX ? -2 : 0,
-                        doY ? -1 : 0,
-                        doZ ? -2 : 0,
-                        doX ? 3 : 1,
-                        doY ? 4 : 1,
-                        doZ ? 3 : 1,
-                        null,
-                        ToolHandler.materialsPick,
-                        silk,
-                        fortune);
+                            player,
+                            world,
+                            x,
+                            y,
+                            z,
+                            doX ? -2 : 0,
+                            doY ? -1 : 0,
+                            doZ ? -2 : 0,
+                            doX ? 3 : 1,
+                            doY ? 4 : 1,
+                            doZ ? 3 : 1,
+                            null,
+                            ToolHandler.materialsPick,
+                            silk,
+                            fortune);
                 }
 
                 break;
@@ -158,21 +163,21 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
 
                 if (!player.isSneaking()) {
                     ToolHandler.removeBlocksInIteration(
-                        player,
-                        world,
-                        x,
-                        y,
-                        z,
-                        xo >= 0 ? 0 : -10,
-                        yo >= 0 ? 0 : -10,
-                        zo >= 0 ? 0 : -10,
-                        xo > 0 ? 10 : 1,
-                        yo > 0 ? 10 : 1,
-                        zo > 0 ? 10 : 1,
-                        null,
-                        ToolHandler.materialsPick,
-                        silk,
-                        fortune);
+                            player,
+                            world,
+                            x,
+                            y,
+                            z,
+                            xo >= 0 ? 0 : -10,
+                            yo >= 0 ? 0 : -10,
+                            zo >= 0 ? 0 : -10,
+                            xo > 0 ? 10 : 1,
+                            yo > 0 ? 10 : 1,
+                            zo > 0 ? 10 : 1,
+                            null,
+                            ToolHandler.materialsPick,
+                            silk,
+                            fortune);
                 }
                 break;
             }

--- a/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
@@ -108,7 +108,7 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
 
         if (player.isSneaking()) {
             if (ConfigHandler.bedrockDimensionID != 0) {
-                // Bedrock → Portal (Overworld low Y OR Bedrock dimension high Y)
+                // Bedrock -> Portal (Overworld low Y OR Bedrock dimension high Y)
                 if (blk == Blocks.bedrock) {
                     if ((world.provider.isSurfaceWorld() && y < 5)
                             || (y > 253 && world.provider instanceof WorldProviderBedrock)) {
@@ -119,7 +119,7 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
                                 ThaumicTinkerer.registry.getFirstBlockFromClass(BlockBedrockPortal.class));
                     }
 
-                    // Bedrock → Air (Bedrock dimension normal Y)
+                    // Bedrock -> Air (Bedrock dimension normal Y)
                     if (y <= 253 && world.provider instanceof WorldProviderBedrock) {
                         world.setBlock(x, y, z, Blocks.air);
                     }

--- a/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
@@ -106,10 +106,14 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
         int fortune = EnchantmentHelper.getFortuneModifier(player);
         boolean silk = EnchantmentHelper.getSilkTouchModifier(player);
         if (ConfigHandler.bedrockDimensionID != 0 && blk == Blocks.bedrock && ((world.provider.isSurfaceWorld() && y < 5) || (y > 253 && world.provider instanceof WorldProviderBedrock))) {
-            world.setBlock(x, y, z, ThaumicTinkerer.registry.getFirstBlockFromClass(BlockBedrockPortal.class));
+            if (player.isSneaking()) {
+                world.setBlock(x, y, z, ThaumicTinkerer.registry.getFirstBlockFromClass(BlockBedrockPortal.class));
+            }
         }
         if (ConfigHandler.bedrockDimensionID != 0 && blk == Blocks.bedrock && (y <= 253 && world.provider instanceof WorldProviderBedrock)) {
-            world.setBlock(x, y, z, Blocks.air);
+            if (player.isSneaking()) {
+                world.setBlock(x, y, z, Blocks.air);
+            }
         }
         switch (ToolHandler.getMode(stack)) {
             case 0:
@@ -119,7 +123,8 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
                 boolean doY = direction.offsetY == 0;
                 boolean doZ = direction.offsetZ == 0;
 
-                ToolHandler.removeBlocksInIteration(
+                if (!player.isSneaking()) {
+                    ToolHandler.removeBlocksInIteration(
                         player,
                         world,
                         x,
@@ -135,6 +140,7 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
                         ToolHandler.materialsPick,
                         silk,
                         fortune);
+                }
 
                 break;
             }
@@ -143,7 +149,8 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
                 int yo = -direction.offsetY;
                 int zo = -direction.offsetZ;
 
-                ToolHandler.removeBlocksInIteration(
+                if (!player.isSneaking()) {
+                    ToolHandler.removeBlocksInIteration(
                         player,
                         world,
                         x,
@@ -159,6 +166,7 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
                         ToolHandler.materialsPick,
                         silk,
                         fortune);
+                }
                 break;
             }
         }

--- a/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
@@ -106,24 +106,16 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
         int fortune = EnchantmentHelper.getFortuneModifier(player);
         boolean silk = EnchantmentHelper.getSilkTouchModifier(player);
 
-        if (player.isSneaking()) {
-            if (ConfigHandler.bedrockDimensionID != 0) {
-                // Bedrock -> Portal (Overworld low Y OR Bedrock dimension high Y)
-                if (blk == Blocks.bedrock) {
-                    if ((world.provider.isSurfaceWorld() && y < 5)
-                            || (y > 253 && world.provider instanceof WorldProviderBedrock)) {
-                        world.setBlock(
-                                x,
-                                y,
-                                z,
-                                ThaumicTinkerer.registry.getFirstBlockFromClass(BlockBedrockPortal.class));
-                    }
+        if (player.isSneaking() && ConfigHandler.bedrockDimensionID != 0 && blk == Blocks.bedrock) {
+            // Bedrock -> Portal (Overworld low Y OR Bedrock dimension high Y)
+            if ((world.provider.isSurfaceWorld() && y < 5)
+                    || (y > 253 && world.provider instanceof WorldProviderBedrock)) {
+                world.setBlock(x, y, z, ThaumicTinkerer.registry.getFirstBlockFromClass(BlockBedrockPortal.class));
+            }
 
-                    // Bedrock -> Air (Bedrock dimension normal Y)
-                    if (y <= 253 && world.provider instanceof WorldProviderBedrock) {
-                        world.setBlock(x, y, z, Blocks.air);
-                    }
-                }
+            // Bedrock -> Air (Bedrock dimension normal Y)
+            if (y <= 253 && world.provider instanceof WorldProviderBedrock) {
+                world.setBlock(x, y, z, Blocks.air);
             }
         }
 

--- a/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/tool/ItemIchorPickAdv.java
@@ -105,16 +105,23 @@ public class ItemIchorPickAdv extends ItemIchorPick implements IAdvancedTool {
         ForgeDirection direction = ForgeDirection.getOrientation(block.sideHit);
         int fortune = EnchantmentHelper.getFortuneModifier(player);
         boolean silk = EnchantmentHelper.getSilkTouchModifier(player);
-        if (ConfigHandler.bedrockDimensionID != 0 && blk == Blocks.bedrock && ((world.provider.isSurfaceWorld() && y < 5) || (y > 253 && world.provider instanceof WorldProviderBedrock))) {
-            if (player.isSneaking()) {
-                world.setBlock(x, y, z, ThaumicTinkerer.registry.getFirstBlockFromClass(BlockBedrockPortal.class));
+
+        if (player.isSneaking()) {
+            if (ConfigHandler.bedrockDimensionID != 0) {
+                // Bedrock → Portal (Overworld low Y OR Bedrock dimension high Y)
+                if (blk == Blocks.bedrock) {
+                    if ((world.provider.isSurfaceWorld() && y < 5) || (y > 253 && world.provider instanceof WorldProviderBedrock)) {
+                        world.setBlock(x, y, z, ThaumicTinkerer.registry.getFirstBlockFromClass(BlockBedrockPortal.class));
+                    }
+
+                    // Bedrock → Air (Bedrock dimension normal Y)
+                    if (y <= 253 && world.provider instanceof WorldProviderBedrock) {
+                        world.setBlock(x, y, z, Blocks.air);
+                    }
+                }
             }
         }
-        if (ConfigHandler.bedrockDimensionID != 0 && blk == Blocks.bedrock && (y <= 253 && world.provider instanceof WorldProviderBedrock)) {
-            if (player.isSneaking()) {
-                world.setBlock(x, y, z, Blocks.air);
-            }
-        }
+
         switch (ToolHandler.getMode(stack)) {
             case 0:
                 break;

--- a/src/main/java/thaumic/tinkerer/common/item/kami/tool/ToolHandler.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/tool/ToolHandler.java
@@ -42,14 +42,14 @@ import thaumic.tinkerer.common.dim.WorldProviderBedrock;
 
 public final class ToolHandler {
 
-    public static Material[] materialsShovel = new Material[] { Material.grass, Material.ground, Material.sand,
+    public final static Material[] materialsShovel = new Material[] { Material.grass, Material.ground, Material.sand,
             Material.snow, Material.craftedSnow, Material.clay };
-    public static Material[] materialsPick = Stream.concat(
+    public final static Material[] materialsPick = Stream.concat(
             Arrays.stream(
                     new Material[] { Material.rock, Material.iron, Material.ice, Material.glass, Material.piston,
                             Material.anvil }),
             Arrays.stream(materialsShovel)).toArray(Material[]::new);
-    public static Material[] materialsAxe = new Material[] { Material.coral, Material.leaves, Material.plants,
+    public final static Material[] materialsAxe = new Material[] { Material.coral, Material.leaves, Material.plants,
             Material.wood };
 
     public static int getMode(ItemStack tool) {

--- a/src/main/java/thaumic/tinkerer/common/item/kami/tool/ToolHandler.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/tool/ToolHandler.java
@@ -106,6 +106,15 @@ public final class ToolHandler {
 
         // only effective materials
         if (!block.canHarvestBlock(player, meta) || !isRightMaterial(block.getMaterial(), materialsListing)) return;
+
+        if (block == Blocks.bedrock) {
+            // Ignore top & bottom 2 bedrock layers (Bedrock dimension only)
+            if (y > 253 && world.provider instanceof WorldProviderBedrock) return;
+
+            // Ignore bedrock in all other dimensions
+            if (!(world.provider instanceof WorldProviderBedrock)) return;
+        }
+
         Block refBlock = world.getBlock(refX, refY, refZ);
         float refStrength = ForgeHooks.blockStrength(refBlock, player, world, refX, refY, refZ);
         float strength = ForgeHooks.blockStrength(block, player, world, x, y, z);

--- a/src/main/java/thaumic/tinkerer/common/item/kami/tool/ToolHandler.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/tool/ToolHandler.java
@@ -11,7 +11,9 @@
  */
 package thaumic.tinkerer.common.item.kami.tool;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -40,10 +42,13 @@ import thaumic.tinkerer.common.dim.WorldProviderBedrock;
 
 public final class ToolHandler {
 
-    public static Material[] materialsPick = new Material[] { Material.rock, Material.iron, Material.ice,
-            Material.glass, Material.piston, Material.anvil };
     public static Material[] materialsShovel = new Material[] { Material.grass, Material.ground, Material.sand,
             Material.snow, Material.craftedSnow, Material.clay };
+    public static Material[] materialsPick = Stream.concat(
+            Arrays.stream(
+                    new Material[] { Material.rock, Material.iron, Material.ice, Material.glass, Material.piston,
+                            Material.anvil }),
+            Arrays.stream(materialsShovel)).toArray(Material[]::new);
     public static Material[] materialsAxe = new Material[] { Material.coral, Material.leaves, Material.plants,
             Material.wood };
 

--- a/src/main/java/thaumic/tinkerer/common/item/kami/tool/ToolHandler.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/tool/ToolHandler.java
@@ -74,7 +74,6 @@ public final class ToolHandler {
         for (int x1 = xs; x1 < xe; x1++) {
             for (int y1 = ys; y1 < ye; y1++) {
                 for (int z1 = zs; z1 < ze; z1++) {
-                    if (x == x1 + x && y == y1 + y && z == z1 + z) continue;
                     Block lock2 = world.getBlock(x1 + x, y1 + y, z1 + z);
 
                     breakExtraBlock(player.worldObj, x1 + x, y1 + y, z1 + z, player, x, y, z, materialsListing);


### PR DESCRIPTION
This PR addresses several issues with the **Awakened Ichorium Pickaxe**, improving both its bedrock‑breaking behaviour and its portal‑creation controls.

Fixes Included:
- Center block not breaking when mining bedrock in line or square mode.
- Bedrock portal now only spawns when holding Shift, preventing accidental portal creation.
- AOE mining is disabled while holding Shift.
- Allow Pickaxe to break dirt, grass, gravel and sand although it isn't the fastest to break them.
- Prevent bedrock from being broken in any dim that is not the bedrock dim (This now includes AOE)

These changes make the tool’s behaviour more predictable and prevent accidental portals or incomplete bedrock mining patterns.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19668

Before / After Comparisons
Pickaxe Before:  

https://github.com/user-attachments/assets/539bb484-4c17-40c0-aef0-aa128f77d838

Pickaxe After:  

https://github.com/user-attachments/assets/5280c2e9-16b5-44f8-8678-f013a84497b7

Portal Creation Before:  

https://github.com/user-attachments/assets/deb5d18d-fe11-42f6-a751-abe6fc063e6d

Portal Creation After:  

https://github.com/user-attachments/assets/0135f894-e086-4706-8ae6-c89beaa3eac5