### PR TITLE
Drain power from electric hoe of growth instead of damaging it

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/compat/EMTCompat.java
+++ b/src/main/java/thaumic/tinkerer/common/compat/EMTCompat.java
@@ -1,9 +1,12 @@
 package thaumic.tinkerer.common.compat;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
+import ic2.api.item.ElectricItem;
 
 public class EMTCompat {
 
@@ -12,5 +15,13 @@ public class EMTCompat {
 
     public static void init() {
         electricHoe = GameRegistry.findItem("EMT", "ElectricHoeGrowth");
+    }
+
+    public static boolean validElectricHoe(ItemStack stack) {
+        return EMTLoaded && stack.getItem() == EMTCompat.electricHoe && ElectricItem.manager.canUse(stack, 250);
+    }
+
+    public static void useEnergy(ItemStack hoeOfGrowth, EntityPlayer player) {
+        ElectricItem.manager.use(hoeOfGrowth, 250, player);
     }
 }

--- a/src/main/java/thaumic/tinkerer/common/core/helper/BonemealEventHandler.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/BonemealEventHandler.java
@@ -2,7 +2,10 @@ package thaumic.tinkerer.common.core.helper;
 
 import static thaumic.tinkerer.common.compat.EMTCompat.EMTLoaded;
 
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.BonemealEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
@@ -31,20 +34,20 @@ public class BonemealEventHandler {
 
     public static boolean isMagicHoe(ItemStack stack) {
         if (stack == null) return false;
-        var item = stack.getItem();
-        return item == ConfigItems.itemHoeElemental || (EMTLoaded && item == EMTCompat.electricHoe);
+        Item item = stack.getItem();
+        return item == ConfigItems.itemHoeElemental || EMTCompat.validElectricHoe(stack);
     }
 
     @SubscribeEvent
     public void onPlayerInteract(PlayerInteractEvent event) {
-        var world = event.world;
+        World world = event.world;
         if (world.isRemote) return;
         if (!(world.getBlock(event.x, event.y, event.z) instanceof BlockInfusedGrain infusedGrain)) return;
 
-        var player = event.entityPlayer;
+        EntityPlayer player = event.entityPlayer;
         if (player == null) return;
 
-        var hoeOfGrowth = player.getCurrentEquippedItem();
+        ItemStack hoeOfGrowth = player.getCurrentEquippedItem();
         if (!isMagicHoe(hoeOfGrowth)) return;
 
         if (!infusedGrain.func_149851_a(world, event.x, event.y, event.z, false)
@@ -52,7 +55,7 @@ public class BonemealEventHandler {
             return;
         }
         infusedGrain.func_149853_b(world, world.rand, event.x, event.y, event.z);
-        hoeOfGrowth.damageItem(25, player);
+        damageHoe(hoeOfGrowth, player);
         Thaumcraft.proxy.blockSparkle(world, event.x, event.y, event.z, 0, 2);
         world.playSoundEffect(
                 event.x + 0.5D,
@@ -61,5 +64,13 @@ public class BonemealEventHandler {
                 "thaumcraft:wand",
                 0.75F,
                 0.9F + world.rand.nextFloat() * 0.2F);
+    }
+
+    private static void damageHoe(ItemStack hoeOfGrowth, EntityPlayer player) {
+        if (EMTLoaded && hoeOfGrowth.getItem() == EMTCompat.electricHoe) {
+            EMTCompat.useEnergy(hoeOfGrowth, player);
+        } else {
+            hoeOfGrowth.damageItem(25, player);
+        }
     }
 }


### PR DESCRIPTION
Previously the hoe would just break, making it a more expensive version of the hoe it's made from. Now it properly drains power and fails to be used when it doesn't have enough.