### PR TITLE
Fixes for [Client thread/ERROR]: Couldn't render entity

### DIFF
--- a/src/main/java/thaumic/tinkerer/client/core/proxy/TTClientProxy.java
+++ b/src/main/java/thaumic/tinkerer/client/core/proxy/TTClientProxy.java
@@ -61,7 +61,6 @@ import thaumic.tinkerer.common.block.tile.tablet.TileAnimationTablet;
 import thaumic.tinkerer.common.compat.FumeTool;
 import thaumic.tinkerer.common.compat.LoadedMods;
 import thaumic.tinkerer.common.core.handler.ConfigHandler;
-import thaumic.tinkerer.common.core.helper.EnumMobAspect;
 import thaumic.tinkerer.common.core.proxy.TTCommonProxy;
 import thaumic.tinkerer.common.item.ItemInfusedSeeds;
 import thaumic.tinkerer.common.item.ItemMobDisplay;
@@ -155,9 +154,11 @@ public final class TTClientProxy extends TTCommonProxy {
         RenderingRegistry.registerBlockHandler(new RenderMagnet());
         RenderingRegistry.registerBlockHandler(new RenderRepairer());
 
+        RenderMobDisplay mobDisplayRenderer = new RenderMobDisplay();
+        MinecraftForge.EVENT_BUS.register(mobDisplayRenderer);
         MinecraftForgeClient.registerItemRenderer(
                 ThaumicTinkerer.registry.getFirstItemFromClass(ItemMobDisplay.class),
-                new RenderMobDisplay());
+                mobDisplayRenderer);
         MinecraftForgeClient.registerItemRenderer(
                 ThaumicTinkerer.registry.getFirstItemFromClass(ItemInfusedSeeds.class),
                 new RenderGenericSeeds());
@@ -219,10 +220,5 @@ public final class TTClientProxy extends TTCommonProxy {
     @Override
     public EntityPlayer getClientPlayer() {
         return ClientHelper.clientPlayer();
-    }
-
-    @Override
-    public String getMobDisplayName(EnumMobAspect aspect) {
-        return aspect.getEntity(Minecraft.getMinecraft().theWorld).getCommandSenderName();
     }
 }

--- a/src/main/java/thaumic/tinkerer/client/render/item/RenderMobDisplay.java
+++ b/src/main/java/thaumic/tinkerer/client/render/item/RenderMobDisplay.java
@@ -1,18 +1,42 @@
 package thaumic.tinkerer.client.render.item;
 
+import java.util.EnumMap;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
-import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
 import net.minecraftforge.client.IItemRenderer;
+import net.minecraftforge.event.world.WorldEvent;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import thaumic.tinkerer.common.core.helper.EnumMobAspect;
 import thaumic.tinkerer.common.item.ItemMobDisplay;
 
 public class RenderMobDisplay implements IItemRenderer {
+
+    private static final int ATTRIB_MASK = GL11.GL_ENABLE_BIT | GL11.GL_CURRENT_BIT
+            | GL11.GL_DEPTH_BUFFER_BIT
+            | GL11.GL_COLOR_BUFFER_BIT
+            | GL11.GL_LIGHTING_BIT
+            | GL11.GL_TEXTURE_BIT;
+
+    private final EnumMap<EnumMobAspect, EntityLiving> cache = new EnumMap<>(EnumMobAspect.class);
+    private World cachedWorld;
+
+    private void setCachedWorld(World world) {
+        cache.clear();
+        cachedWorld = world;
+    }
+
+    @SubscribeEvent
+    public void onWorldUnload(WorldEvent.Unload event) {
+        if (event.world == cachedWorld) setCachedWorld(null);
+    }
 
     @Override
     public boolean handleRenderType(ItemStack itemStack, ItemRenderType itemRenderType) {
@@ -30,19 +54,31 @@ public class RenderMobDisplay implements IItemRenderer {
         if (!(itemStack.getItem() instanceof ItemMobDisplay item)) return;
         EnumMobAspect aspect = item.getEntityType(itemStack);
         if (aspect == null) return;
-        Entity entity = EnumMobAspect.getEntityFromCache(aspect, Minecraft.getMinecraft().theWorld);
-        float scale = aspect.getScale();
-        float offset = aspect.getVerticalOffset();
-        GL11.glPushMatrix();
-        GL11.glRotatef(-30.0F, 1.0F, 0.0F, 0.0F);
-        GL11.glScalef(scale, scale, scale);
-        GL11.glTranslatef(0, (-entity.height / 2) + offset, 0.0F);
-        Render renderer = RenderManager.instance.getEntityRenderObject(entity);
-        if (renderer != null && renderer.getFontRendererFromRenderManager() != null) {
-            GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
-            renderer.doRender(entity, 0, 0, 0, 0, 0);
-            GL11.glPopAttrib();
+
+        final World world = Minecraft.getMinecraft().theWorld;
+        if (world != cachedWorld) setCachedWorld(world);
+        if (world == null) return;
+
+        EntityLiving entity = cache.get(aspect);
+        if (entity == null || entity.worldObj != world) {
+            entity = aspect.createEntity(world);
+            cache.put(aspect, entity);
         }
-        GL11.glPopMatrix();
+
+        final Render renderer = RenderManager.instance.getEntityRenderObject(entity);
+        if (renderer == null || renderer.getFontRendererFromRenderManager() == null) return;
+
+        float scale = aspect.getScale();
+        GL11.glPushMatrix();
+        GL11.glPushAttrib(ATTRIB_MASK);
+        try {
+            GL11.glRotatef(-30.0F, 1.0F, 0.0F, 0.0F);
+            GL11.glScalef(scale, scale, scale);
+            GL11.glTranslatef(0, (-entity.height / 2) + aspect.getVerticalOffset(), 0.0F);
+            renderer.doRender(entity, 0, 0, 0, 0, 0);
+        } finally {
+            GL11.glPopAttrib();
+            GL11.glPopMatrix();
+        }
     }
 }

--- a/src/main/java/thaumic/tinkerer/common/core/helper/EnumMobAspect.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/EnumMobAspect.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.monster.EntityBlaze;
@@ -37,15 +37,9 @@ import net.minecraft.entity.passive.EntitySheep;
 import net.minecraft.entity.passive.EntitySquid;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.passive.EntityWolf;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.world.WorldEvent;
 
-import com.google.common.collect.Maps;
-
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.common.entities.monster.EntityBrainyZombie;
 import thaumcraft.common.entities.monster.EntityFireBat;
@@ -125,7 +119,6 @@ public enum EnumMobAspect {
     Enderman(EntityEnderman.class, new Aspect[] { Aspect.ELDRITCH, Aspect.ELDRITCH, Aspect.MAN }, 0.7f),
     Wisp(EntityWisp.class, new Aspect[] { Aspect.AIR, Aspect.MAGIC, Aspect.MAGIC });
 
-    public static final Map<EnumMobAspect, EntityLiving> entityCache = Maps.newHashMap();
     private static final Map<String, EnumMobAspect> LOOKUP = Arrays.stream(values())
             .collect(Collectors.toMap(Enum::name, Function.identity()));
     public final Aspect[] aspects;
@@ -133,6 +126,7 @@ public enum EnumMobAspect {
     private final float scale;
     private final float offset;
     private final MethodHandle ctor;
+    private String langKey;
 
     EnumMobAspect(Class<? extends EntityLiving> entity, Aspect[] aspects, float scale) {
         this(entity, aspects, scale, 0);
@@ -157,15 +151,6 @@ public enum EnumMobAspect {
 
     public static EnumMobAspect get(String name) {
         return LOOKUP.get(name);
-    }
-
-    public static EntityLiving getEntityFromCache(EnumMobAspect ent, World worldObj) {
-        EntityLiving entity = entityCache.get(ent);
-        if (entity == null) {
-            entity = ent.createEntity(worldObj);
-            entityCache.put(ent, entity);
-        }
-        return entity;
     }
 
     private static EntityLiving setSlimeSize(EntityLiving entity, int size) {
@@ -206,8 +191,12 @@ public enum EnumMobAspect {
         return scale;
     }
 
-    public EntityLiving getEntity(World worldObj) {
-        return getEntityFromCache(this, worldObj);
+    public String getDisplayName() {
+        if (langKey == null) {
+            String name = EntityList.classToStringMapping.get(entity);
+            langKey = "entity." + (name == null ? "generic" : name) + ".name";
+        }
+        return StatCollector.translateToLocal(langKey);
     }
 
     public EntityLiving createEntity(World worldObj) {
@@ -215,22 +204,6 @@ public enum EnumMobAspect {
             return (EntityLiving) ctor.invoke(worldObj);
         } catch (Throwable e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    static {
-        MinecraftForge.EVENT_BUS.register(new EventHandler());
-    }
-
-    public static class EventHandler {
-
-        @SideOnly(Side.CLIENT)
-        @SubscribeEvent
-        public void onWorldUnload(WorldEvent.Unload event) {
-            Minecraft mc = Minecraft.getMinecraft();
-            if (event.world == mc.theWorld) {
-                entityCache.clear();
-            }
         }
     }
 }

--- a/src/main/java/thaumic/tinkerer/common/core/proxy/TTCommonProxy.java
+++ b/src/main/java/thaumic/tinkerer/common/core/proxy/TTCommonProxy.java
@@ -77,7 +77,6 @@ import thaumic.tinkerer.common.core.handler.kami.KamiDimensionHandler;
 import thaumic.tinkerer.common.core.handler.kami.SoulHeartHandler;
 import thaumic.tinkerer.common.core.helper.AspectCropLootManager;
 import thaumic.tinkerer.common.core.helper.BonemealEventHandler;
-import thaumic.tinkerer.common.core.helper.EnumMobAspect;
 import thaumic.tinkerer.common.core.helper.NumericAspectHelper;
 import thaumic.tinkerer.common.enchantment.ModEnchantments;
 import thaumic.tinkerer.common.enchantment.core.EnchantmentManager;
@@ -274,10 +273,6 @@ public class TTCommonProxy {
 
     public void shadowSparkle(World world, float x, float y, float z, int size) {
         // NO-OP
-    }
-
-    public String getMobDisplayName(EnumMobAspect aspect) {
-        return aspect.getEntity(MinecraftServer.getServer().getEntityWorld()).getCommandSenderName();
     }
 
     public static class NEIEventHandler {

--- a/src/main/java/thaumic/tinkerer/common/item/ItemMobDisplay.java
+++ b/src/main/java/thaumic/tinkerer/common/item/ItemMobDisplay.java
@@ -6,7 +6,6 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
-import thaumic.tinkerer.common.ThaumicTinkerer;
 import thaumic.tinkerer.common.core.helper.EnumMobAspect;
 import thaumic.tinkerer.common.core.helper.ItemNBTHelper;
 import thaumic.tinkerer.common.lib.LibItemNames;
@@ -64,6 +63,6 @@ public class ItemMobDisplay extends ItemBase {
         if (mob == null || mob.isEmpty()) return super.getItemStackDisplayName(stack);
         EnumMobAspect aspect = EnumMobAspect.get(mob);
         if (aspect == null) return super.getItemStackDisplayName(stack);
-        return ThaumicTinkerer.proxy.getMobDisplayName(aspect);
+        return aspect.getDisplayName();
     }
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
* Handle a null world properly
* Reduce glPushAttrib to used bits
* Cache langkey

Fixes:
```
[19:29:26] [Client thread/ERROR]: Couldn't render entity
java.lang.NullPointerException: Cannot invoke "net.minecraft.world.World.func_72899_e(int, int, int)" because "this.field_70170_p" is null
	at Launch//net.minecraft.entity.Entity.func_70013_c(Entity.java:1102) ~[sa.class:?]
	at Launch//net.minecraft.client.renderer.entity.RendererLivingEntity.func_76986_a(RendererLivingEntity.java:214) [boh.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderLiving.func_76986_a(SourceFile:23) [bok.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderChicken.func_76986_a(SourceFile:18) [bng.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderChicken.func_76986_a(SourceFile:9) [bng.class:?]
	at Launch//thaumic.tinkerer.client.render.item.RenderMobDisplay.renderItem(RenderMobDisplay.java:43) [RenderMobDisplay.class:?]
	at Launch//net.minecraftforge.client.ForgeHooksClient.renderInventoryItem(ForgeHooksClient.java:183) [ForgeHooksClient.class:?]
	at Launch//net.minecraft.client.renderer.entity.RenderItem.func_82406_b(RenderItem.java:563) [bny.class:?]
	at Launch//codechicken.nei.guihook.GuiContainerManager.lambda$drawItem$0(GuiContainerManager.java:349) [GuiContainerManager.class:?]
	at Launch//codechicken.nei.guihook.GuiContainerManager.safeItemRenderContext(GuiContainerManager.java:385) [GuiContainerManager.class:?]
	at Launch//codechicken.nei.guihook.GuiContainerManager.drawItem(GuiContainerManager.java:323) [GuiContainerManager.class:?]
	at Launch//codechicken.nei.guihook.GuiContainerManager.drawItem(GuiContainerManager.java:309) [GuiContainerManager.class:?]
	at Launch//codechicken.nei.ItemsGrid$ItemsGridSlot.drawItem(ItemsGrid.java:195) [ItemsGrid$ItemsGridSlot.class:?]
	at Launch//codechicken.nei.ItemsGrid$ItemsGridSlot.drawItem(ItemsGrid.java:180) [ItemsGrid$ItemsGridSlot.class:?]
	at Launch//codechicken.nei.ItemsPanelGrid$ItemsPanelGridSlot.drawItem(ItemsPanelGrid.java:66) [ItemsPanelGrid$ItemsPanelGridSlot.class:?]
	at Launch//codechicken.nei.ItemsGrid.drawItems(ItemsGrid.java:521) [ItemsGrid.class:?]
	at Launch//codechicken.nei.ItemsGrid.draw(ItemsGrid.java:557) [ItemsGrid.class:?]
	at Launch//codechicken.nei.ItemsPanelGrid.draw(ItemsPanelGrid.java:243) [ItemsPanelGrid.class:?]
	at Launch//codechicken.nei.PanelWidget.draw(PanelWidget.java:162) [PanelWidget.class:?]
	at Launch//codechicken.nei.LayoutManager.renderObjects(LayoutManager.java:277) [LayoutManager.class:?]
	at Launch//codechicken.nei.guihook.GuiContainerManager.renderObjects(GuiContainerManager.java:576) [GuiContainerManager.class:?]
	at Launch//net.minecraft.client.gui.inventory.GuiContainer.func_73863_a(GuiContainer.java:120) [bex.class:?]
	at Launch//net.minecraft.client.renderer.EntityRenderer.func_78480_b(EntityRenderer.java:1061) [blt.class:?]
	at Launch//net.minecraft.client.Minecraft.redirect$zcf000$angelica$skipRenderWhenIconified(Minecraft.java:4451) [bao.class:?]
	at Launch//net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1001) [bao.class:?]
	at Launch//net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:9610) [bao.class:?]
	at Launch//net.minecraft.client.main.Main.main(SourceFile:148) [Main.class:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:565) ~[?:?]
	at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250) [Launch.class:?]
	at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35) [Launch.class:?]
	at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60) [Launch.class:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:565) ~[?:?]
	at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207) [lwjgl3ify-3.0.31-forgePatches.jar:3.0.31]
	at com.gtnewhorizons.retrofuturabootstrap.MainStartOnFirstThread.lambda$main$1(MainStartOnFirstThread.java:47) [lwjgl3ify-3.0.31-forgePatches.jar:3.0.31]
	at java.base/java.lang.Thread.run(Thread.java:1474) [?:?]
```


## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
