### PR TITLE
Modify Infused Seed Drops

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
@@ -152,7 +152,7 @@ public class AspectCropLootManager {
         addAspectLoot(Aspect.MIND, new ItemStack(Items.paper, 64), 15);
         addAspectLoot(Aspect.MIND, new ItemStack(Items.book, 32), 10);
         addAspectLoot(Aspect.MIND, new ItemStack(Blocks.bookshelf, 16), 5);
-        addAspectLoot(Aspect.MIND, new ItemStack(ConfigItems.itemResource, 4, 9), 5);
+        addAspectLoot(Aspect.MIND, new ItemStack(ConfigItems.itemResource, 4, 9), 5); // knowledge fragment
 
         addAspectLoot(Aspect.FLESH, new ItemStack(ConfigItems.itemResource, 16, 5), 1);
 
@@ -162,7 +162,7 @@ public class AspectCropLootManager {
         addAspectLoot(
                 Aspect.CRAFT,
                 new ItemStack(ThaumicTinkerer.registry.getFirstBlockFromClass(BlockDarkQuartz.class), 32));
-        addAspectLoot(Aspect.CRAFT, new ItemStack(ConfigBlocks.blockStoneDevice, 16));
+        addAspectLoot(Aspect.CRAFT, new ItemStack(ConfigBlocks.blockStoneDevice, 2)); // runic matrix
         addAspectLoot(Aspect.CRAFT, new ItemStack(Blocks.crafting_table, 4));
 
         addAspectLoot(Aspect.HUNGER, new ItemStack(Items.nether_wart, 16));
@@ -171,6 +171,7 @@ public class AspectCropLootManager {
         addAspectLoot(Aspect.COLD, new ItemStack(Items.snowball, 64));
         addAspectLoot(Aspect.COLD, new ItemStack(Blocks.snow, 32));
         addAspectLoot(Aspect.COLD, new ItemStack(Blocks.snow_layer, 8));
+        addAspectLoot(Aspect.COLD, "rodBlizz", 1);
 
         addAspectLoot(Aspect.PLANT, "grass");
         addAspectLoot(Aspect.PLANT, "sapling");
@@ -196,7 +197,7 @@ public class AspectCropLootManager {
         addAspectLoot(Aspect.GREED, new ItemStack(Items.emerald, 2));
 
         addAspectLoot(Aspect.LIGHT, new ItemStack(Items.glowstone_dust, 16), 5);
-        addAspectLoot(Aspect.LIGHT, new ItemStack(ConfigItems.itemResource, 4, 1));
+        addAspectLoot(Aspect.LIGHT, new ItemStack(ConfigItems.itemResource, 4, 1)); // nitor
         addAspectLoot(
                 Aspect.LIGHT,
                 new ItemStack(ThaumicTinkerer.registry.getFirstItemFromClass(ItemBrightNitor.class)));
@@ -226,7 +227,7 @@ public class AspectCropLootManager {
         addAspectLoot(Aspect.EXCHANGE, "ingotCopper", 4);
         addAspectLoot(Aspect.EXCHANGE, new ItemStack(ConfigBlocks.blockCustomOre, 4));
 
-        addAspectLoot(Aspect.ENERGY, new ItemStack(ConfigItems.itemResource, 12));
+        addAspectLoot(Aspect.ENERGY, new ItemStack(ConfigItems.itemResource, 12)); // alumentum
 
         addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 0));
         addAspectLoot(Aspect.MAGIC, new ItemStack(ConfigItems.itemShard, 1, 1));
@@ -257,8 +258,8 @@ public class AspectCropLootManager {
         addAspectLoot(Aspect.VOID, "bowl");
         addAspectLoot(Aspect.VOID, new ItemStack(ConfigItems.itemResource, 1, 17)); // void seed
 
-        addAspectLoot(Aspect.POISON, new ItemStack(ConfigItems.itemResource, 16, 3));
-        addAspectLoot(Aspect.POISON, new ItemStack(Items.spider_eye, 8, 1));
+        addAspectLoot(Aspect.POISON, new ItemStack(ConfigItems.itemResource, 16, 3)); // quicksilver
+        addAspectLoot(Aspect.POISON, new ItemStack(Items.spider_eye, 8));
 
         addAspectLoot(Aspect.LIFE, new ItemStack(Items.egg, 8));
 
@@ -266,12 +267,12 @@ public class AspectCropLootManager {
         addAspectLoot(Aspect.TRAP, "trapdoorWood");
         addAspectLoot(Aspect.TRAP, new ItemStack(ConfigItems.itemResource, 16, 6)); // amber
 
-        addAspectLoot(Aspect.TRAVEL, new ItemStack(ConfigBlocks.blockCosmeticSolid, 4, 2));
+        addAspectLoot(Aspect.TRAVEL, new ItemStack(ConfigBlocks.blockCosmeticSolid, 4, 2)); // paved stone of travel
 
         addAspectLoot(Aspect.TAINT, new ItemStack(ConfigItems.itemResource, 4, 11));
 
         addAspectLoot(Aspect.CRYSTAL, new ItemStack(Items.diamond, 1));
-        addAspectLoot(Aspect.CRYSTAL, new ItemStack(Items.quartz, 1));
+        addAspectLoot(Aspect.CRYSTAL, new ItemStack(Items.quartz, 8));
         addAspectLoot(Aspect.CRYSTAL, new ItemStack(Blocks.glass, 32), 4);
     }
 }

--- a/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
@@ -162,7 +162,7 @@ public class AspectCropLootManager {
         addAspectLoot(
                 Aspect.CRAFT,
                 new ItemStack(ThaumicTinkerer.registry.getFirstBlockFromClass(BlockDarkQuartz.class), 32));
-        addAspectLoot(Aspect.CRAFT, new ItemStack(ConfigBlocks.blockStoneDevice, 2)); // runic matrix
+        addAspectLoot(Aspect.CRAFT, new ItemStack(ConfigBlocks.blockStoneDevice, 16, 0)); // alchemical furnace
         addAspectLoot(Aspect.CRAFT, new ItemStack(Blocks.crafting_table, 4));
 
         addAspectLoot(Aspect.HUNGER, new ItemStack(Items.nether_wart, 16));

--- a/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
@@ -140,6 +140,7 @@ public class AspectCropLootManager {
         addAspectLoot(Aspect.ELDRITCH, new ItemStack(Items.ender_pearl, 4), 10);
         addAspectLoot(Aspect.ELDRITCH, new ItemStack(Items.ender_eye, 4), 5);
         addAspectLoot(Aspect.ELDRITCH, "bucketEnder");
+        addAspectLoot(Aspect.ELDRITCH, new ItemStack(ConfigItems.itemResource, 1, 17)); // void seed
 
         addAspectLoot(Aspect.TREE, "logWood");
 
@@ -255,8 +256,8 @@ public class AspectCropLootManager {
 
         addAspectLoot(Aspect.VOID, new ItemStack(Items.bucket));
         addAspectLoot(Aspect.VOID, "bucket");
-        addAspectLoot(Aspect.VOID, "bowl");
-        addAspectLoot(Aspect.VOID, new ItemStack(ConfigItems.itemResource, 1, 17)); // void seed
+        addAspectLoot(Aspect.VOID, "bowl", 4);
+        addAspectLoot(Aspect.VOID, "ingotVoid", 2);
 
         addAspectLoot(Aspect.POISON, new ItemStack(ConfigItems.itemResource, 16, 3)); // quicksilver
         addAspectLoot(Aspect.POISON, new ItemStack(Items.spider_eye, 8));

--- a/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
@@ -264,7 +264,7 @@ public class AspectCropLootManager {
 
         addAspectLoot(Aspect.TRAP, new ItemStack(Blocks.web, 4));
         addAspectLoot(Aspect.TRAP, "trapdoorWood");
-        new ItemStack(ConfigItems.itemResource, 16, 6); // amber
+        addAspectLoot(Aspect.TRAP, new ItemStack(ConfigItems.itemResource, 16, 6)); // amber
 
         addAspectLoot(Aspect.TRAVEL, new ItemStack(ConfigBlocks.blockCosmeticSolid, 4, 2));
 

--- a/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
@@ -272,6 +272,6 @@ public class AspectCropLootManager {
 
         addAspectLoot(Aspect.CRYSTAL, new ItemStack(Items.diamond, 1));
         addAspectLoot(Aspect.CRYSTAL, new ItemStack(Items.quartz, 1));
-        addAspectLoot(Aspect.CRYSTAL, new ItemStack(Blocks.glass), 100);
+        addAspectLoot(Aspect.CRYSTAL, new ItemStack(Blocks.glass, 32), 4);
     }
 }

--- a/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
@@ -152,10 +152,12 @@ public class AspectCropLootManager {
         addAspectLoot(Aspect.MIND, new ItemStack(Items.paper, 64), 15);
         addAspectLoot(Aspect.MIND, new ItemStack(Items.book, 32), 10);
         addAspectLoot(Aspect.MIND, new ItemStack(Blocks.bookshelf, 16), 5);
+        addAspectLoot(Aspect.MIND, new ItemStack(ConfigItems.itemResource, 4, 9), 5);
 
         addAspectLoot(Aspect.FLESH, new ItemStack(ConfigItems.itemResource, 16, 5), 1);
 
         addAspectLoot(Aspect.UNDEAD, new ItemStack(Items.rotten_flesh, 32));
+        addAspectLoot(Aspect.UNDEAD, new ItemStack(Items.bone, 24));
 
         addAspectLoot(
                 Aspect.CRAFT,
@@ -169,7 +171,6 @@ public class AspectCropLootManager {
         addAspectLoot(Aspect.COLD, new ItemStack(Items.snowball, 64));
         addAspectLoot(Aspect.COLD, new ItemStack(Blocks.snow, 32));
         addAspectLoot(Aspect.COLD, new ItemStack(Blocks.snow_layer, 8));
-        addAspectLoot(Aspect.COLD, "rodBlizz", 1);
 
         addAspectLoot(Aspect.PLANT, "grass");
         addAspectLoot(Aspect.PLANT, "sapling");
@@ -189,9 +190,10 @@ public class AspectCropLootManager {
         addAspectLoot(Aspect.TOOL, new ItemStack(ConfigItems.itemShovelThaumium));
         addAspectLoot(Aspect.TOOL, new ItemStack(ConfigItems.itemAxeThaumium));
 
-        addAspectLoot(Aspect.SLIME, "slime");
+        addAspectLoot(Aspect.SLIME, "slime", 4);
 
         addAspectLoot(Aspect.GREED, new ItemStack(Items.gold_ingot, 4));
+        addAspectLoot(Aspect.GREED, new ItemStack(Items.emerald, 2));
 
         addAspectLoot(Aspect.LIGHT, new ItemStack(Items.glowstone_dust, 16), 5);
         addAspectLoot(Aspect.LIGHT, new ItemStack(ConfigItems.itemResource, 4, 1));
@@ -200,8 +202,12 @@ public class AspectCropLootManager {
                 new ItemStack(ThaumicTinkerer.registry.getFirstItemFromClass(ItemBrightNitor.class)));
 
         addAspectLoot(Aspect.MECHANISM, new ItemStack(Blocks.piston, 8));
+        addAspectLoot(Aspect.MECHANISM, new ItemStack(Blocks.hopper, 4));
+        addAspectLoot(Aspect.MECHANISM, new ItemStack(Blocks.dropper, 8));
+        addAspectLoot(Aspect.MECHANISM, new ItemStack(Blocks.dispenser, 8));
 
         addAspectLoot(Aspect.CROP, new ItemStack(Items.wheat, 32));
+        addAspectLoot(Aspect.CROP, "seed");
 
         addAspectLoot(Aspect.METAL, new ItemStack(Items.iron_ingot, 4), 100);
 
@@ -241,8 +247,6 @@ public class AspectCropLootManager {
         }
 
         addAspectLoot(Aspect.SOUL, new ItemStack(Blocks.soul_sand, 16), 2);
-        addAspectLoot(Aspect.SOUL, new ItemStack(Blocks.netherrack, 32), 2);
-        addAspectLoot(Aspect.SOUL, new ItemStack(Blocks.nether_brick));
 
         addAspectLoot(Aspect.WEATHER, "cloud", 64);
 
@@ -251,17 +255,23 @@ public class AspectCropLootManager {
         addAspectLoot(Aspect.VOID, new ItemStack(Items.bucket));
         addAspectLoot(Aspect.VOID, "bucket");
         addAspectLoot(Aspect.VOID, "bowl");
+        addAspectLoot(Aspect.VOID, new ItemStack(ConfigItems.itemResource, 1, 17)); // void seed
 
         addAspectLoot(Aspect.POISON, new ItemStack(ConfigItems.itemResource, 16, 3));
+        addAspectLoot(Aspect.POISON, new ItemStack(Items.spider_eye, 8, 1));
 
         addAspectLoot(Aspect.LIFE, new ItemStack(Items.egg, 8));
 
         addAspectLoot(Aspect.TRAP, new ItemStack(Blocks.web, 4));
         addAspectLoot(Aspect.TRAP, "trapdoorWood");
+        new ItemStack(ConfigItems.itemResource, 16, 6); // amber
+
+        addAspectLoot(Aspect.TRAVEL, new ItemStack(ConfigBlocks.blockCosmeticSolid, 4, 2));
 
         addAspectLoot(Aspect.TAINT, new ItemStack(ConfigItems.itemResource, 4, 11));
 
-        addAspectLoot(Aspect.CRYSTAL, "gemDiamond");
+        addAspectLoot(Aspect.CRYSTAL, new ItemStack(Items.diamond, 1));
+        addAspectLoot(Aspect.CRYSTAL, new ItemStack(Items.quartz, 1));
         addAspectLoot(Aspect.CRYSTAL, new ItemStack(Blocks.glass), 100);
     }
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Did a pass over the infused seed drops, mostly adding items, but removing 2 enetries (netherrack from SOUL, which didn't fit under soul, and as a whole has no aspect it fits under, and rodBlizz from COLD which I moved to NHCoreMod since they're gt items.)

Balance-concerning changes: 

1. Vacuous (VOID): + Void seed
    a. Imo this change won't matter too much in terms of vanilla, and even less for GTNH as efficient farming of infused seeds requires the hoe of growth, which is post-infusion (MV w/ skip, HV normally), and it breaks them awfully fast. Mass-making void seeds would be much, much easier and faster with the thaumic bases void seed plant which can go in the EIG and be world accelerated with a normal accelerator, not TE, and later, the EEC. 
3. Messis (CROP): + wildcard oredic "seed"
    a. Again, little to no concern for Thaumic Tinkerer by itself. For GTNH, there's a chance that an unintended seed has been added, which I will check asap in full pack if I haven't already. 




## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
